### PR TITLE
Remove stale P&T dependency

### DIFF
--- a/upbound.yaml
+++ b/upbound.yaml
@@ -6,8 +6,6 @@ spec:
   dependsOn:
   - provider: xpkg.upbound.io/upbound/provider-helm
     version: v0
-  - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
-    version: v0.8.2
   - function: xpkg.upbound.io/crossplane-contrib/function-auto-ready
     version: '>=v0.0.0'
   description: |


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Remove stale P&T dependency

It should also solve the conflict in higher level platform-ref-*

See related https://github.com/upbound/configuration-observability-oss/pull/90

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
