### PR TITLE
Propagate labels from XR down to Release

### DIFF
--- a/examples/app/app-xr.yaml
+++ b/examples/app/app-xr.yaml
@@ -3,6 +3,9 @@ kind: App
 metadata:
   name: configuration-app
   namespace: default
+  labels:
+    platform.upbound.io/deletion-ordering: enabled
+    test-label: test-value
 spec:
   parameters:
     helm:

--- a/functions/app/main.k
+++ b/functions/app/main.k
@@ -24,7 +24,9 @@ _defaults = {
  
 _items = [
     helmv1beta1.Release {
-        metadata = _metadata("helmRelease")
+        metadata = _metadata("helmRelease") | {
+            labels = oxr.metadata.labels or {}
+        }
         spec = _defaults | {
             forProvider = {
                 chart = {

--- a/tests/test-app/main.k
+++ b/tests/test-app/main.k
@@ -11,6 +11,10 @@ _items = [
                     metadata = {
                         name = "configuration-app"
                         namespace = "default"
+                        labels = {
+                            "platform.upbound.io/deletion-ordering" = "enabled"
+                            "test-label" = "test-value"
+                        }
                     }
                     spec = {
                         parameters = {
@@ -29,6 +33,10 @@ _items = [
                     metadata = {
                         annotations = {
                             "crossplane.io/composition-resource-name" = "helmRelease"
+                        }
+                        labels = {
+                            "platform.upbound.io/deletion-ordering" = "enabled"
+                            "test-label" = "test-value"
                         }
                         ownerReferences = [
                             {


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fix regression that happened with 2.0.0 release

We need to set ordering label for creating dynamic App usage in higher level abstractions like platform-ref-{aws,azure,gcp}

Without the fix, we can't label Release for proper ordering as in example from platform-ref-azure

```
crossplane beta trace cluster.azure.platformref.upbound.io/platform-ref-azure-e2e

NAME                                                                                            SYNCED   READY   STATUS
Cluster/platform-ref-azure-e2e (default)                                                        True     False   Creating: Unready resources: usage-aks-by-arbitrary-labeled-release
├─ AKS/composite-cluster-aks (default)                                                          True     True    Available
│  ├─ KubernetesCluster/platform-ref-azure-e2e-aks (default)                                    True     True    Available
│  ├─ ProviderConfig/platform-ref-azure-e2e (default)                                           -        -
│  ├─ Object/platform-ref-azure-e2e-fa2a18d49ccc (default)                                      True     True    Available
│  └─ ProviderConfig/platform-ref-azure-e2e (default)                                           -        -
├─ Network/composite-network-aks (default)                                                      True     True    Available
│  ├─ ResourceGroup/platform-ref-azure-e2e-rg (default)                                         True     True    Available
│  ├─ Subnet/platform-ref-azure-e2e-db-sn-0 (default)                                           True     True    Available
│  ├─ Subnet/platform-ref-azure-e2e-sn (default)                                                True     True    Available
│  └─ VirtualNetwork/platform-ref-azure-e2e-vnet (default)                                      True     True    Available
├─ Flux/composite-flux (default)                                                                True     True    Available
│  ├─ Release/release-flux (default)                                                            True     True    Available
│  └─ Release/sync-flux (default)                                                               True     True    Available
├─ Oss/composite-observability-oss (default)                                                    True     True    Available
│  ├─ Release/releaseprometheus-platform-ref-azure-e2e (default)                                True     True    Available
│  ├─ Object/podmonitorcrossplane-platform-ref-azure-e2e (default)                              True     True    Available
│  ├─ Object/podmonitorcrossplaneproviders-platform-ref-azure-e2e (default)                     True     True    Available
│  ├─ Object/podmonitorcrossplanerbacmanager-platform-ref-azure-e2e (default)                   True     True    Available
│  ├─ Usage/usageprometheusbypodmonitorcrossplane-platform-ref-azure-e2e (default)              -        True    Available
│  ├─ Usage/usageprometheusbypodmonitorcrossplanerbacmanager-platform-ref-azure-e2e (default)   -        True    Available
│  └─ Usage/usageprometheusbypodmonitorproviders-platform-ref-azure-e2e (default)               -        True    Available
├─ Usage/usage-aks-by-arbitrary-labeled-release (default)                                       -        -  <--- Usage never gets ready because the release is not labeled
├─ Usage/usage-aks-by-flux (default)                                                            -        True    Available
└─ Usage/usage-aks-by-oss (default)                                                             -        True    Available
```

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
